### PR TITLE
fix: JWT 段落解碼改用 Base64.getUrlDecoder()

### DIFF
--- a/core-system/twdiw-oid4vci-handler/src/main/java/gov/moda/dw/issuer/oidvci/web/rest/CredentialIssuer.java
+++ b/core-system/twdiw-oid4vci-handler/src/main/java/gov/moda/dw/issuer/oidvci/web/rest/CredentialIssuer.java
@@ -214,7 +214,7 @@ public class CredentialIssuer
                     String nonce = null;
                     String credential_configuration_id = null;
                     String tx_code = null;
-                    JSONObject IDT_payload_obj = (JSONObject)new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE).parse(Base64.getDecoder().decode(IDT_payload));
+                    JSONObject IDT_payload_obj = (JSONObject)new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE).parse(Base64.getUrlDecoder().decode(IDT_payload));
 
                     try
                     {
@@ -1661,7 +1661,7 @@ public class CredentialIssuer
                 final String payload_str = split_jwt[1];
                 final String signature_str = split_jwt[2];
 
-                JSONObject header_obj = (JSONObject)new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE).parse(Base64.getDecoder().decode(header_str));
+                JSONObject header_obj = (JSONObject)new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE).parse(Base64.getUrlDecoder().decode(header_str));
                 jwt_kid = header_obj.getAsString("kid");
                 String typ = header_obj.getAsString("typ");
                 String alg = header_obj.getAsString("alg");
@@ -1733,7 +1733,7 @@ public class CredentialIssuer
                     return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(ret_json.toJSONString(JSONStyle.LT_COMPRESS));
                 }
 
-                JSONObject payload_obj = (JSONObject)new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE).parse(Base64.getDecoder().decode(payload_str));
+                JSONObject payload_obj = (JSONObject)new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE).parse(Base64.getUrlDecoder().decode(payload_str));
                 jwt_client_id = payload_obj.getAsString("iss");
                 jwt_credential_identifier = payload_obj.getAsString("aud");
                 jwt_c_nonce = payload_obj.getAsString("nonce");


### PR DESCRIPTION
## 描述

`CredentialIssuer.java` 使用 `Base64.getDecoder()`（標準 base64，RFC 4648 §4）解析
JWT header 與 payload 段落。JWT 規格（RFC 7515 §2）要求使用 base64url 編碼（RFC 4648 §5）。
外部 Wallet 的 key proof JWT 含有 `-` 或 `_`——ES256 簽章幾乎必然出現——解碼器會拋出
`IllegalArgumentException`，簽發端回傳 `400 Bad Request`。

## 相關 Issue

Fixes #18

## 變更類型

- [x] 錯誤修復（修復問題的非破壞性變更）

## 所做的變更

- `CredentialIssuer.java:217` — `Base64.getDecoder()` → `Base64.getUrlDecoder()`（IDT payload，預授權流程）
- `CredentialIssuer.java:1664` — `Base64.getDecoder()` → `Base64.getUrlDecoder()`（key proof JWT header）
- `CredentialIssuer.java:1736` — `Base64.getDecoder()` → `Base64.getUrlDecoder()`（key proof JWT payload）

三處相同的一字替換，無邏輯變更，無需新增 import。

## 測試

#### 測試配置
- Java 版本：17
- 元件：`twdiw-oid4vci-handler`

#### 測試案例
- [ ] 含 base64url 字元（`-`、`_`）的 key proof JWT header 能正確解析
- [ ] 含 base64url 字元（`-`、`_`）的 key proof JWT payload 能正確解析
- [ ] 使用符合規格的 OID4VCI 客戶端（如 EUDI Reference Wallet）端到端憑證簽發成功
- [ ] 預授權流程（IDT payload 路徑）正確解析

#### 測試結果

符合規格的 ES256 JWT 每次請求約有 50% 機率產生含 `-` 或 `_` 的 base64url 段落。
若要確定性驗證，取任何外部 Wallet 實際送出的 key proof JWT，確認不再拋出 `IllegalArgumentException`。

## 破壞性變更

- [ ] 此 PR 引入破壞性變更

## 文件

- [ ] 已更新 README.md
- [ ] 已更新 API 文件
- [x] 已新增／更新程式碼註解
- [ ] 已更新 CHANGELOG.md

## 檢查清單

#### 程式碼品質
- [x] 程式碼遵循專案風格
- [x] 已完成自我審查
- [x] 變更不產生新的警告

#### 法律
- [x] 我已閱讀並同意[貢獻者授權協議](../CLA.md)
- [x] 此貢獻是我的原創作品
- [x] 我有權在 MIT 授權下提交此作品

---

## 其他備註

**為何內部測試難以發現此問題**：TWDIW 自家 Dart SDK 可能規避或正規化 base64url 字元，導致內部測試通過，但所有符合規格的外部客戶端間歇性失敗。

**規格層次**：RFC 7515/7519 規定所有 JWT 段落使用 base64url 編碼——VCDM 1.1 `jwt_vc_json`、VCDM 2.0 `dc+sd-jwt`、SD-JWT VC 均適用。RFC 4648 §5（base64url）定義在所有 VC 規格的下層。