### PR TITLE
nitpick: SD-JWT 解碼改用 Dart 原生 base64Url codec

### DIFF
--- a/APP/APPSDK/lib/utils/utils.dart
+++ b/APP/APPSDK/lib/utils/utils.dart
@@ -42,16 +42,8 @@ class Utils {
         continue;
       }
 
-      // 修正 Base64URL 格式並補齊 padding
-      String base64Url = part.replaceAll('-', '+').replaceAll('_', '/');
-      int padding = 4 - (base64Url.length % 4);
-      if (padding < 4) {
-        base64Url += '=' * padding;
-      }
-
       try {
-        // Base64 Decode
-        String decoded = utf8.decode(base64.decode(base64Url));
+        String decoded = utf8.decode(base64.decode(base64Url.normalize(part)));
         List<String> decodedList = List<String>.from(json.decode(decoded));
 
         if (decodedList.length == 3) {
@@ -106,15 +98,7 @@ class Utils {
           continue;
         }
 
-        // 修正 Base64URL 格式並補齊 padding
-        String base64Url = part.replaceAll('-', '+').replaceAll('_', '/');
-        int padding = 4 - (base64Url.length % 4);
-        if (padding < 4) {
-          base64Url += '=' * padding;
-        }
-
-        // Base64 Decode
-        String decoded = utf8.decode(base64.decode(base64Url));
+        String decoded = utf8.decode(base64.decode(base64Url.normalize(part)));
 
         // 僅保留包含指定欄位的部分
         for (var field in fields) {


### PR DESCRIPTION
# nitpick: SD-JWT 解碼改用 Dart 原生 base64Url codec

## 說明

Dart APPSDK 中的 `Utils.sdJwtDecode` 與 `Utils.sdJwtEncode` 在解碼 base64url 字串時，
手動將 `-`→`+`、`_`→`/` 並自行補齊 padding，再呼叫 `base64.decode()`。
Dart 的 `dart:convert` 函式庫已內建 `base64Url` codec，並提供 `normalize()` 方法自動補齊 padding，
整段手動轉換可精簡為一個表達式。

手動轉換寫法冗長、容易出錯（padding 條件容易 off-by-one），且遮蔽了程式意圖。
改用標準函式庫 codec 是 Dart 的慣用寫法。

## 相關 Issue

Closes #（issue 編號）

## 變更類型

- [x] Bug 修復 / 重構（不影響行為的改善）

## 修改內容

**`APP/APPSDK/lib/utils/utils.dart`**

`sdJwtDecode` — 將手動轉換（原 5 行）替換為單一表達式：

```dart
// 修改前
String base64Url = part.replaceAll('-', '+').replaceAll('_', '/');
int padding = 4 - (base64Url.length % 4);
if (padding < 4) {
  base64Url += '=' * padding;
}
// Base64 Decode
String decoded = utf8.decode(base64.decode(base64Url));

// 修改後
String decoded = utf8.decode(base64.decode(base64Url.normalize(part)));
```

`sdJwtEncode` — 相同替換（原 109–117 行）。

## 測試

#### 測試環境
- Flutter SDK：3.5.1
- Dart：^3.5.1
- 元件：`APP/APPSDK`

#### 測試項目
- [ ] `sdJwtDecode` 能正確解碼含有 `-` 或 `_` 的 base64url disclosure 值
- [ ] `sdJwtDecode` 能正確處理需要補齊 padding 的 disclosure
- [ ] `sdJwtEncode` 對已知 SD-JWT 的輸出與修改前一致
- [ ] `verifyJwt` 不受影響（其 `base64Url.decode` 呼叫獨立存在）

## 重大變更

- [ ] 本 PR 包含重大變更

## 文件更新

- [ ] README.md 已更新
- [ ] API 文件已更新
- [x] 程式碼註解已更新（移除過時的「修正 Base64URL 格式並補齊 padding」註解）
- [ ] CHANGELOG.md 已更新

## 檢查清單

#### 程式碼品質
- [x] 程式碼符合專案風格規範
- [x] 已自行審閱程式碼
- [x] 修改不會產生新的警告

#### 法律聲明
- [x] 已閱讀並同意[貢獻者授權協議](../CLA.md)
- [x] 本貢獻為本人原創作品
- [x] 本人有權依 MIT 授權提交此作品