### PR TITLE
ci: 新增 PR spotless:check workflow（僅對有異動的模組執行）

### DIFF
--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -1,0 +1,74 @@
+name: Spotless Check
+
+on:
+  pull_request:
+    paths:
+      - 'core-system/**/*.java'
+      - 'core-system/**/pom.xml'
+
+jobs:
+  changes:
+    name: Detect changed modules
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            # 新增模組時，在此依相同格式加一個 entry，filter 名稱須與 core-system/ 下的目錄名稱完全一致。
+            # When adding a new module, append an entry here following the same pattern.
+            # The filter name must exactly match the directory name under core-system/.
+            moda-digitalwallet-common:
+              - 'core-system/moda-digitalwallet-common/**/*.java'
+              - 'core-system/moda-digitalwallet-common/**/pom.xml'
+            twdiw-issuer-api:
+              - 'core-system/twdiw-issuer-api/**/*.java'
+              - 'core-system/twdiw-issuer-api/**/pom.xml'
+            twdiw-oid4vci-handler:
+              - 'core-system/twdiw-oid4vci-handler/**/*.java'
+              - 'core-system/twdiw-oid4vci-handler/**/pom.xml'
+            twdiw-oid4vp-handler:
+              - 'core-system/twdiw-oid4vp-handler/**/*.java'
+              - 'core-system/twdiw-oid4vp-handler/**/pom.xml'
+            twdiw-vc-handler:
+              - 'core-system/twdiw-vc-handler/**/*.java'
+              - 'core-system/twdiw-vc-handler/**/pom.xml'
+            twdiw-verifier-api:
+              - 'core-system/twdiw-verifier-api/**/*.java'
+              - 'core-system/twdiw-verifier-api/**/pom.xml'
+            twdiw-vp-handler:
+              - 'core-system/twdiw-vp-handler/**/*.java'
+              - 'core-system/twdiw-vp-handler/**/pom.xml'
+
+  spotless:
+    name: spotless:check — ${{ matrix.module }}
+    needs: changes
+    if: ${{ needs.changes.outputs.modules != '[]' && needs.changes.outputs.modules != '' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.changes.outputs.modules) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Install parent POM
+        run: mvn install -N --no-transfer-progress -f core-system/moda-digitalwallet-parent-pom/pom.xml
+
+      - name: Run spotless:check
+        run: |
+          mvn spotless:check --no-transfer-progress -f core-system/${{ matrix.module }}/pom.xml || {
+            echo "::error::${{ matrix.module }}: format violations found. Run 'mvn spotless:apply' locally to fix."
+            exit 1
+          }


### PR DESCRIPTION
## 說明

新增 GitHub Actions workflow，在每個 PR 自動執行 `mvn spotless:check`，實現 Issue #22 提到的 CI 防護。

設計重點：只對 PR 中實際有異動的模組執行格式檢查，不對全部 7 個模組跑，節省 CI 時間。

Close #22（CI防護部分）

## 變更類型

- [x] CI/CD changes / CI/CD 變更

## 修改內容

新增 `.github/workflows/spotless-check.yml`，兩個 job 設計：

**`changes` job** — 使用 `dorny/paths-filter@v3` 偵測哪些模組有 `.java` 或 `pom.xml` 異動，輸出一個 JSON array（例如 `["twdiw-issuer-api", "twdiw-vc-handler"]`）。

**`spotless` job** — 直接以 `changes` 的 JSON array 作為 matrix，對每個有異動的模組平行執行 `mvn spotless:check`。若有格式違規，提示開發者執行 `mvn spotless:apply` 修正。

```
pull_request（*.java 或 pom.xml 有異動）
    │
    ▼
[changes]  dorny/paths-filter → modules = ["twdiw-issuer-api"]
    │
    ▼
[spotless matrix]
  └── spotless:check — twdiw-issuer-api
```

涵蓋所有 7 個 Java 模組：
- `moda-digitalwallet-common`
- `twdiw-issuer-api`
- `twdiw-oid4vci-handler`
- `twdiw-oid4vp-handler`
- `twdiw-vc-handler`
- `twdiw-verifier-api`
- `twdiw-vp-handler`

## 測試

#### 測試項目
- [ ] 開一個只改 `twdiw-issuer-api` Java 檔案的 PR，確認只有 `spotless:check — twdiw-issuer-api` 這個 check 出現
- [ ] 格式違規時 workflow 應失敗並顯示「Run 'mvn spotless:apply' locally to fix.」錯誤訊息
- [ ] 沒有 Java / pom.xml 異動的 PR 不觸發 workflow

## 重大變更

- [ ] 本 PR 包含重大變更

## 文件更新

- [ ] README.md 已更新
- [ ] API 文件已更新
- [ ] 程式碼註解已新增／更新
- [ ] CHANGELOG.md 已更新

## 檢查清單

#### 程式碼品質
- [x] 程式碼符合專案風格規範
- [x] 已自行審閱程式碼
- [x] 修改不會產生新的警告

#### 法律聲明
- [x] 已閱讀並同意[貢獻者授權協議](../CLA.md)
- [x] 本貢獻為本人原創作品
- [x] 本人有權依 MIT 授權提交此作品