### PR TITLE
Fix qrcode sample code

### DIFF
--- a/SampleCode/ECCService.java
+++ b/SampleCode/ECCService.java
@@ -47,6 +47,13 @@ public class ECCService {
     private static final String KDF_ALGO = "SHA-256";
     private static final int SYMMETRIC_KEY_SIZE = 32; // 256 bits
 
+    // 封包前綴中記錄 ephemeral 公鑰長度的欄位大小（4 bytes）
+    private static final int KEY_LENGTH_FIELD_SIZE = 4;
+    // X25519 公鑰以 X.509 SubjectPublicKeyInfo 封裝後的固定長度（44 bytes）
+    private static final int X25519_SPKI_LENGTH = 44;
+    // ChaCha20-Poly1305 認證標籤長度（16 bytes），密文至少須包含此標籤
+    private static final int POLY1305_TAG_LENGTH = 16;
+
     /**
      * 產生 ECC 金鑰對
      * 
@@ -168,12 +175,20 @@ public class ECCService {
      * @param encryptedBase64 Base64 編碼的加密資料，格式為：[ephemeral 公鑰長度(4 bytes) + ephemeral 公鑰 + nonce + 加密資料]
      * @param privateKeyBase64 Base64 編碼的私鑰
      * @return 解密後的明文
-     * @throws Exception 當解密過程發生錯誤時拋出
+     * @throws IllegalArgumentException 當加密資料長度不足或 ephemeral 公鑰長度欄位不正確時拋出
+     * @throws SecurityException MAC 驗證失敗（資料遭竄改）時拋出
+     * @throws Exception 當解密過程發生其他錯誤時拋出
      */
     public String decrypt(String encryptedBase64, String privateKeyBase64) throws Exception {
         try {
             // 1. Base64 解碼取得原始加密資料
             byte[] input = Base64.getDecoder().decode(encryptedBase64);
+
+            // 檢核封包總長度是否足以容納「長度欄位 + ephemeral 公鑰 + nonce + 最小密文（僅認證標籤）」
+            if (input.length < KEY_LENGTH_FIELD_SIZE + X25519_SPKI_LENGTH + NONCE_LENGTH + POLY1305_TAG_LENGTH) {
+                // 長度不足代表資料非本格式或已遭截斷，直接拒絕
+                throw new IllegalArgumentException("加密資料長度不足，無法解析");
+            }
 
             // 2. 載入私鑰（Base64 解碼 → PKCS8EncodedKeySpec → PrivateKey）
             KeyFactory kf = KeyFactory.getInstance(KEY_AGREEMENT_ALGO);
@@ -181,15 +196,23 @@ public class ECCService {
                     new java.security.spec.PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyBase64)));
 
             // 3. 分離 ephemeral 公鑰長度、公鑰、nonce、密文
-            byte[] keyLengthBytes = new byte[4];
-            System.arraycopy(input, 0, keyLengthBytes, 0, 4);
+            byte[] keyLengthBytes = new byte[KEY_LENGTH_FIELD_SIZE];
+            System.arraycopy(input, 0, keyLengthBytes, 0, KEY_LENGTH_FIELD_SIZE);
             int ephemeralPubKeyLength = bytesToInt(keyLengthBytes);
+
+            // 檢核長度欄位是否為 X25519 公鑰的固定長度
+            // 此欄位完全由輸入方控制，未檢核時可指定極大值造成過量記憶體配置（OutOfMemoryError）
+            if (ephemeralPubKeyLength != X25519_SPKI_LENGTH) {
+                // 長度不符即代表資料格式錯誤，於配置記憶體前先行拒絕
+                throw new IllegalArgumentException("ephemeral 公鑰長度不正確");
+            }
 
             byte[] ephemeralPubKeyBytes = new byte[ephemeralPubKeyLength];
             byte[] nonce = new byte[NONCE_LENGTH];
-            byte[] ciphertext = new byte[input.length - 4 - ephemeralPubKeyLength - NONCE_LENGTH];
+            // 密文長度為總長扣除長度欄位、公鑰與 nonce；上方檢核已確保此值不為負
+            byte[] ciphertext = new byte[input.length - KEY_LENGTH_FIELD_SIZE - ephemeralPubKeyLength - NONCE_LENGTH];
 
-            int offset = 4;
+            int offset = KEY_LENGTH_FIELD_SIZE;
             System.arraycopy(input, offset, ephemeralPubKeyBytes, 0, ephemeralPubKeyLength);
             offset += ephemeralPubKeyLength;
             System.arraycopy(input, offset, nonce, 0, NONCE_LENGTH);

--- a/SampleCode/HMACService.java
+++ b/SampleCode/HMACService.java
@@ -68,8 +68,9 @@ public class HMACService {
      */
     public String calculateHMAC(String data, String key) throws Exception {
         // 記錄開始計算的日誌
-        logger.info("開始計算(calculateHMAC) HMAC:{},{}", data, key);
-        
+        // 注意：嚴禁將 data（可能含個資）與 key（HMAC 金鑰）寫入日誌，金鑰外洩即可偽造任意通過驗證的 QR Code
+        logger.info("開始計算(calculateHMAC)");
+
         // 將 Base64 格式的金鑰轉換為位元組陣列
         byte[] keyBytes = Base64.getDecoder().decode(key);
         

--- a/SampleCode/VerifyQRCodeController.java
+++ b/SampleCode/VerifyQRCodeController.java
@@ -15,8 +15,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // 引入 JSON 處理相關類別
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
+
+// 引入常數時間比對與字元編碼相關類別
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 
 // 引入服務層類別
 import com.example.demo.service.TOTPService;
@@ -24,11 +29,15 @@ import com.example.demo.service.HMACService;
 
 /**
  * QR Code 驗證控制器
- * 此控制器負責驗證 QR Code 的內容，包含：
- * 1. RSA 解密
+ * 此控制器示範驗證端於離線環境自行解密數位憑證皮夾所出示 QR Code 的完整流程，包含：
+ * 1. ECC 解密（X25519 ECDH + ChaCha20-Poly1305）
  * 2. TOTP 驗證
  * 3. HMAC 驗證
  * 4. 資料完整性檢查
+ *
+ * 驗證邏輯與驗證端模組的 DWVP-05-404 API 一致：
+ * - HMAC 的計算對象為「整段解密後明文」，比對目標為 QR Code 的 h 欄位
+ * - 解密後明文中僅 totp 為必填欄位，其餘欄位由數位憑證皮夾端定義
  */
 @RestController
 @RequestMapping("/api")
@@ -53,60 +62,50 @@ public class VerifyQRCodeController {
 
     /**
      * 驗證 QR Code 內容
-     * 
-     * @param request 包含加密資料和驗證金鑰的請求
-     * @return 驗證結果，包含驗證狀態和解密後的資料
+     *
+     * @param request 包含 QR Code 四個欄位與驗證所需金鑰的請求
+     * @return 驗證結果，包含驗證狀態與解密後的資料
      */
     @PostMapping("/verify-qrcode")
-    public ResponseEntity<?> verifyQRCode(@RequestBody VerifyQRCodeRequest request) {
+    public ResponseEntity<VerifyQRCodeResponse> verifyQRCode(@RequestBody VerifyQRCodeRequest request) {
         logger.info("開始驗證 QR Code");
         try {
-            // 驗證請求參數是否完整
+            // 1. 驗證請求參數是否完整
             if (!validateRequest(request)) {
+                // 參數不完整時回傳 400，並以固定訊息說明必填欄位
                 return ResponseEntity.badRequest().body(new VerifyQRCodeResponse(
-                    "請求參數驗證失敗：請確保所有必要參數都已提供且不為空",
+                    "請求參數驗證失敗：t、d、h、k 與 privateKey、totpKey、hmacKey 皆為必填",
                     false,
                     null
                 ));
             }
 
-            // 1. 解密 DATA 欄位內容
-            logger.info("開始解密 DATA 欄位內容");
-            String decryptedData = eccService.decrypt(request.getEncryptedData(), request.getPrivateKey());
-            logger.info("解密完成，解密後的資料：{}", decryptedData);
-            
-            // 輸出解密後的明文到日誌
-            logger.info("==========================================");
-            logger.info("解密後的明文：");
-            logger.info(decryptedData);
-            logger.info("==========================================");
-            
-            // 解析 JSON 資料
+            // 2. 使用私鑰解密 d 欄位，取得原始明文
+            // 注意：嚴禁將解密後明文寫入日誌，其中包含姓名、電話等個人資料
+            String decryptedData = eccService.decrypt(request.getData(), request.getPrivateKey());
+            logger.info("ECC 解密完成");
+
+            // 3. 將解密後的明文解析為 JSON 物件
             JsonNode dataNode = objectMapper.readTree(decryptedData);
             logger.info("JSON 解析完成");
 
-            // 2. 驗證必要欄位是否存在
-            logger.info("開始驗證必要欄位");
+            // 4. 驗證必要欄位是否存在（與驗證端模組一致，僅 totp 為必填）
             if (!validateRequiredFields(dataNode)) {
+                // 缺少 totp 欄位時視為解密結果不符預期格式
                 return ResponseEntity.ok(new VerifyQRCodeResponse(
-                    "解密失敗：缺少必要欄位 (totp, phone, hmac, name)",
+                    "解密失敗：缺少必要欄位（totp）",
                     false,
                     null
                 ));
             }
-            logger.info("必要欄位驗證通過");
 
-            // 取得各欄位值
+            // 取得 TOTP 碼欄位值
             String totp = dataNode.get("totp").asText();
-            String phone = dataNode.get("phone").asText();
-            String hmac = dataNode.get("hmac").asText();
-            String name = dataNode.get("name").asText();
-            logger.info("取得欄位值：totp={}, phone={}, name={}", totp, phone, name);
 
-            // 3. 驗證 TOTP 碼
-            logger.info("開始驗證 TOTP");
+            // 5. 驗證 TOTP 碼是否有效
             if (!totpService.verifyTOTP(totp, request.getTotpKey())) {
-                logger.error("TOTP 驗證失敗");
+                // TOTP 驗證失敗代表 QR Code 已過期或金鑰不符
+                logger.warn("TOTP 驗證失敗");
                 return ResponseEntity.ok(new VerifyQRCodeResponse(
                     "TOTP 驗證失敗：TOTP 碼無效或已過期",
                     false,
@@ -115,14 +114,15 @@ public class VerifyQRCodeController {
             }
             logger.info("TOTP 驗證通過");
 
-            // 4. 驗證 HMAC 值
-            logger.info("開始驗證 HMAC");
-            String calculatedHmac = hmacService.calculateHMAC(totp + name, request.getHmacKey());
-            logger.info("計算出的 HMAC：{}", calculatedHmac);
-            logger.info("原始 HMAC：{}", hmac);
-            
-            if (!calculatedHmac.equals(hmac)) {
-                logger.error("HMAC 驗證失敗");
+            // 6. 驗證 HMAC 值：對「整段解密後明文」計算，與 QR Code 的 h 欄位比對
+            // 注意：嚴禁將計算結果或金鑰寫入日誌
+            String calculatedHmac = hmacService.calculateHMAC(decryptedData, request.getHmacKey());
+
+            // 以常數時間比對 HMAC，避免逐字元短路比對洩漏比對進度（時序側通道）
+            if (!MessageDigest.isEqual(calculatedHmac.getBytes(StandardCharsets.UTF_8),
+                    request.getHmac().getBytes(StandardCharsets.UTF_8))) {
+                // HMAC 不符代表資料遭竄改或並非由合法發行方產生
+                logger.warn("HMAC 驗證失敗");
                 return ResponseEntity.ok(new VerifyQRCodeResponse(
                     "HMAC 驗證失敗：資料完整性檢查失敗",
                     false,
@@ -131,7 +131,7 @@ public class VerifyQRCodeController {
             }
             logger.info("HMAC 驗證通過");
 
-            // 5. 所有驗證都通過，回傳解密後的資料
+            // 7. 所有驗證都通過，回傳解密後的資料
             logger.info("所有驗證都通過，準備回傳結果");
             return ResponseEntity.ok(new VerifyQRCodeResponse(
                 "驗證成功",
@@ -140,10 +140,10 @@ public class VerifyQRCodeController {
             ));
 
         } catch (Exception e) {
-            // 處理驗證過程中的錯誤
+            // 完整堆疊僅記錄於伺服器端，避免內部細節外洩給呼叫端
             logger.error("驗證過程發生錯誤", e);
             return ResponseEntity.ok(new VerifyQRCodeResponse(
-                "驗證過程發生錯誤：" + e.getMessage(),
+                "驗證過程發生錯誤",
                 false,
                 null
             ));
@@ -152,53 +152,120 @@ public class VerifyQRCodeController {
 
     /**
      * 驗證請求參數是否完整
-     * 
+     *
      * @param request 驗證請求物件
      * @return 如果所有必要參數都存在且不為空則回傳 true，否則回傳 false
      */
     private boolean validateRequest(VerifyQRCodeRequest request) {
-        return request != null &&
-               StringUtils.hasText(request.getEncryptedData()) &&
-               StringUtils.hasText(request.getPrivateKey()) &&
-               StringUtils.hasText(request.getTotpKey()) &&
-               StringUtils.hasText(request.getHmacKey());
+        // 請求物件本身為 null 時直接視為不合法
+        if (request == null) {
+            return false;
+        }
+        // QR Code 的 t 欄位（交易類型）為必填
+        if (!StringUtils.hasText(request.getTag())) {
+            return false;
+        }
+        // QR Code 的 d 欄位（加密資料）為必填
+        if (!StringUtils.hasText(request.getData())) {
+            return false;
+        }
+        // QR Code 的 h 欄位（HMAC 驗證值）為必填
+        if (!StringUtils.hasText(request.getHmac())) {
+            return false;
+        }
+        // QR Code 的 k 欄位（金鑰代碼）為必填
+        if (!StringUtils.hasText(request.getKeyId())) {
+            return false;
+        }
+        // 解密用私鑰為必填
+        if (!StringUtils.hasText(request.getPrivateKey())) {
+            return false;
+        }
+        // TOTP 驗證金鑰為必填
+        if (!StringUtils.hasText(request.getTotpKey())) {
+            return false;
+        }
+        // HMAC 驗證金鑰為必填
+        if (!StringUtils.hasText(request.getHmacKey())) {
+            return false;
+        }
+        // 全部通過
+        return true;
     }
 
     /**
-     * 驗證解密後的資料是否包含所有必要欄位
-     * 
+     * 驗證解密後的資料是否包含必要欄位
+     * 與驗證端模組一致，解密後明文中僅 totp 為必填欄位
+     *
      * @param dataNode JSON 資料節點
-     * @return 如果所有必要欄位都存在且不為空則回傳 true，否則回傳 false
+     * @return 如果 totp 欄位存在且不為空則回傳 true，否則回傳 false
      */
     private boolean validateRequiredFields(JsonNode dataNode) {
-        return dataNode != null &&
-               dataNode.has("totp") &&
-               dataNode.has("phone") &&
-               dataNode.has("hmac") &&
-               dataNode.has("name") &&
-               StringUtils.hasText(dataNode.get("totp").asText()) &&
-               StringUtils.hasText(dataNode.get("phone").asText()) &&
-               StringUtils.hasText(dataNode.get("hmac").asText()) &&
-               StringUtils.hasText(dataNode.get("name").asText());
+        // JSON 節點為 null 時視為不合法
+        if (dataNode == null) {
+            return false;
+        }
+        // 必須存在 totp 欄位
+        if (!dataNode.has("totp")) {
+            return false;
+        }
+        // totp 欄位不得為空字串
+        return StringUtils.hasText(dataNode.get("totp").asText());
     }
 
     /**
      * QR Code 驗證請求物件
-     * 用於接收前端傳來的驗證請求資料
+     * 前四個欄位對應 QR Code 掃描後取得的 JSON 內容，後三個欄位為驗證端持有的金鑰
+     *
+     * 重要：此範例為求呈現完整流程，將三組金鑰放在請求內容中傳遞。
+     * 實際部署時，privateKey、totpKey 與 hmacKey 必須保存在 POS 機本機的設定檔、
+     * 環境變數或安全模組中，嚴禁透過網路請求傳遞，否則金鑰會出現在存取日誌、
+     * APM 追蹤紀錄與例外堆疊之中。
      */
     public static class VerifyQRCodeRequest {
-        private String encryptedData;  // 加密後的資料
-        private String privateKey;     // RSA 私鑰
-        private String totpKey;        // TOTP 金鑰
-        private String hmacKey;        // HMAC 金鑰
+        @JsonProperty("t")
+        private String tag;            // QR Code 的交易類型
+        @JsonProperty("d")
+        private String data;           // QR Code 的加密資料（Base64）
+        @JsonProperty("h")
+        private String hmac;           // QR Code 的 HMAC 驗證值（Base64）
+        @JsonProperty("k")
+        private String keyId;          // QR Code 的金鑰代碼，用於選擇對應的金鑰組
+        private String privateKey;     // X25519 私鑰（Base64 編碼的 PKCS#8 格式）
+        private String totpKey;        // TOTP 金鑰（Base64 編碼，32 位元組）
+        private String hmacKey;        // HMAC 金鑰（Base64 編碼，32 位元組）
 
         // Getters and Setters
-        public String getEncryptedData() {
-            return encryptedData;
+        public String getTag() {
+            return tag;
         }
 
-        public void setEncryptedData(String encryptedData) {
-            this.encryptedData = encryptedData;
+        public void setTag(String tag) {
+            this.tag = tag;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+
+        public String getHmac() {
+            return hmac;
+        }
+
+        public void setHmac(String hmac) {
+            this.hmac = hmac;
+        }
+
+        public String getKeyId() {
+            return keyId;
+        }
+
+        public void setKeyId(String keyId) {
+            this.keyId = keyId;
         }
 
         public String getPrivateKey() {
@@ -237,7 +304,7 @@ public class VerifyQRCodeController {
 
         /**
          * 建構子
-         * 
+         *
          * @param message 回應訊息
          * @param isValid 驗證是否通過
          * @param data 解密後的資料
@@ -273,4 +340,4 @@ public class VerifyQRCodeController {
             this.data = data;
         }
     }
-} 
+}

--- a/core-system/twdiw-verifier-api/src/main/java/gov/moda/dw/manager/service/custom/Dwvp404iService.java
+++ b/core-system/twdiw-verifier-api/src/main/java/gov/moda/dw/manager/service/custom/Dwvp404iService.java
@@ -1,5 +1,7 @@
 package gov.moda.dw.manager.service.custom;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -88,7 +90,10 @@ public class Dwvp404iService {
             // 4. 驗證 HMAC 值
             String calculatedHmac = hmacService.calculateHMAC(orgData, orgKeySetting.getHmacKey());
 
-            if (!calculatedHmac.equals(request.getHmac())) {
+            // 以常數時間比對 HMAC，避免逐字元短路比對洩漏比對進度（時序側通道）
+            // request.getHmac() 為呼叫端可控值，故不可使用 String.equals
+            if (!MessageDigest.isEqual(calculatedHmac.getBytes(StandardCharsets.UTF_8),
+                    request.getHmac().getBytes(StandardCharsets.UTF_8))) {
                 log.error("HMAC 驗證失敗");
                 throw new DWException(StatusCode.DWVP_HMAC_VERIFICATION_FAILED);
             }

--- a/core-system/twdiw-verifier-api/src/main/java/gov/moda/dw/manager/service/custom/common/ECCService.java
+++ b/core-system/twdiw-verifier-api/src/main/java/gov/moda/dw/manager/service/custom/common/ECCService.java
@@ -50,6 +50,13 @@ public class ECCService {
     private static final String KDF_ALGO = "SHA-256";
     private static final int SYMMETRIC_KEY_SIZE = 32; // 256 bits
 
+    // 封包前綴中記錄 ephemeral 公鑰長度的欄位大小（4 bytes）
+    private static final int KEY_LENGTH_FIELD_SIZE = 4;
+    // X25519 公鑰以 X.509 SubjectPublicKeyInfo 封裝後的固定長度（44 bytes）
+    private static final int X25519_SPKI_LENGTH = 44;
+    // ChaCha20-Poly1305 認證標籤長度（16 bytes），密文至少須包含此標籤
+    private static final int POLY1305_TAG_LENGTH = 16;
+
     /**
      * 產生 ECC 金鑰對
      * 
@@ -173,12 +180,20 @@ public class ECCService {
      * @param encryptedBase64 Base64 編碼的加密資料，格式為：[ephemeral 公鑰長度(4 bytes) + ephemeral 公鑰 + nonce + 加密資料]
      * @param privateKeyBase64 Base64 編碼的私鑰
      * @return 解密後的明文
-     * @throws Exception 當解密過程發生錯誤時拋出
+     * @throws IllegalArgumentException 當加密資料長度不足或 ephemeral 公鑰長度欄位不正確時拋出
+     * @throws SecurityException 當 MAC 驗證失敗（資料遭竄改）時拋出
+     * @throws Exception 當解密過程發生其他錯誤時拋出
      */
     public String decrypt(String encryptedBase64, String privateKeyBase64) throws Exception {
         try {
             // 1. Base64 解碼取得原始加密資料
             byte[] input = Base64.getDecoder().decode(encryptedBase64);
+
+            // 檢核封包總長度是否足以容納「長度欄位 + ephemeral 公鑰 + nonce + 最小密文（僅認證標籤）」
+            if (input.length < KEY_LENGTH_FIELD_SIZE + X25519_SPKI_LENGTH + NONCE_LENGTH + POLY1305_TAG_LENGTH) {
+                // 長度不足代表資料非本格式或已遭截斷，直接拒絕
+                throw new IllegalArgumentException("加密資料長度不足，無法解析");
+            }
 
             // 2. 載入私鑰（Base64 解碼 → PKCS8EncodedKeySpec → PrivateKey）
             KeyFactory kf = KeyFactory.getInstance(KEY_AGREEMENT_ALGO);
@@ -186,15 +201,23 @@ public class ECCService {
                     new java.security.spec.PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyBase64)));
 
             // 3. 分離 ephemeral 公鑰長度、公鑰、nonce、密文
-            byte[] keyLengthBytes = new byte[4];
-            System.arraycopy(input, 0, keyLengthBytes, 0, 4);
+            byte[] keyLengthBytes = new byte[KEY_LENGTH_FIELD_SIZE];
+            System.arraycopy(input, 0, keyLengthBytes, 0, KEY_LENGTH_FIELD_SIZE);
             int ephemeralPubKeyLength = bytesToInt(keyLengthBytes);
+
+            // 檢核長度欄位是否為 X25519 公鑰的固定長度
+            // 此欄位完全由輸入方控制，未檢核時可指定極大值造成過量記憶體配置（OutOfMemoryError）
+            if (ephemeralPubKeyLength != X25519_SPKI_LENGTH) {
+                // 長度不符即代表資料格式錯誤，於配置記憶體前先行拒絕
+                throw new IllegalArgumentException("ephemeral 公鑰長度不正確");
+            }
 
             byte[] ephemeralPubKeyBytes = new byte[ephemeralPubKeyLength];
             byte[] nonce = new byte[NONCE_LENGTH];
-            byte[] ciphertext = new byte[input.length - 4 - ephemeralPubKeyLength - NONCE_LENGTH];
+            // 密文長度為總長扣除長度欄位、公鑰與 nonce；上方檢核已確保此值不為負
+            byte[] ciphertext = new byte[input.length - KEY_LENGTH_FIELD_SIZE - ephemeralPubKeyLength - NONCE_LENGTH];
 
-            int offset = 4;
+            int offset = KEY_LENGTH_FIELD_SIZE;
             System.arraycopy(input, offset, ephemeralPubKeyBytes, 0, ephemeralPubKeyLength);
             offset += ephemeralPubKeyLength;
             System.arraycopy(input, offset, nonce, 0, NONCE_LENGTH);


### PR DESCRIPTION
## Pull Request / 拉取請求

### Description / 描述

修正 DWVP-05 離線 QR Code 驗證機制中，公開範例程式與正式實作不一致的問題，並補強兩處資安缺口。

`SampleCode/` 的驗證邏輯與驗證端模組 `Dwvp404iService` 在「HMAC 計算對象」與「必要欄位檢核」上根本不同，照範例實作無法與正式模組互通，且引入可實際利用的資安弱點。本 PR 以正式實作為單一真實來源，修正範例程式，並同步修補正式實作中的記憶體配置與時序側通道問題。

本 PR 不變更任何 API 請求／回應結構，亦未新增或變更錯誤碼，屬零破壞性變更。

### Related Issue / 相關問題

無對應 issue。此問題係於文件與程式碼稽核過程中發現。

<!-- 若需先建立 issue 再關聯，可將下行取消註解並填入編號 -->
<!-- Fixes #(issue number) -->

### Type of Change / 變更類型

- [x] Bug fix / 錯誤修復 (non-breaking change which fixes an issue / 修復問題的非破壞性變更)
- [ ] New feature / 新功能
- [ ] Breaking change / 破壞性變更
- [ ] Documentation update / 文件更新
- [ ] Performance improvement / 效能改進
- [ ] Code refactoring / 程式碼重構
- [ ] Dependency update / 依賴更新
- [ ] CI/CD changes / CI/CD 變更
- [x] Other / 其他: 資安修補（記憶體配置邊界檢核、時序側通道、敏感資料日誌）

### Changes Made / 所做的變更

**core-system（正式實作）**

- **變更 1**：`ECCService.decrypt()` 加入長度邊界檢核。封包前 4 bytes 的 ephemeral 公鑰長度欄位完全由輸入方控制，未檢核時可指定極大值使 `new byte[length]` 觸發 `OutOfMemoryError`。由於 `OutOfMemoryError` 繼承自 `Error` 而非 `Exception`，會穿透 `Dwvp404iService` 與 `Dwvp404iResource` 兩層 `catch (Exception e)`，對 JVM 造成記憶體壓力。修正後於配置記憶體前先檢核封包總長度不小於 76 bytes，且長度欄位須等於 44（X25519 SubjectPublicKeyInfo 固定長度）。

- **變更 2**：`Dwvp404iService` 的 HMAC 比對由 `String.equals()` 改為 `MessageDigest.isEqual()`。`request.getHmac()` 為呼叫端可控值，逐字元短路比對會洩漏比對進度，具時序側通道風險。

**SampleCode（公開範例）**

- **變更 3**：`VerifyQRCodeController` 的驗證邏輯對齊 `Dwvp404iService`
  - HMAC 改為對**整段解密後明文**計算，並與 QR Code 的 `h` 欄位比對。原實作為對 `totp + name` 串接計算後比對密文內部的 `hmac` 欄位，而該欄位實際並不存在於明文中
  - 請求物件改為接收 QR Code 的 `t`/`d`/`h`/`k` 四個必填欄位
  - 解密後明文的必要欄位檢核改為僅 `totp`

- **變更 4**：移除敏感資料日誌
  - `HMACService` 原將 `data` 與 HMAC 金鑰以 INFO 層級寫入日誌。HMAC 金鑰外洩即可偽造任意通過驗證的 QR Code（ECC 為公鑰加密，公鑰公開，密文本身無法證明來源）
  - `VerifyQRCodeController` 原在單次請求中將解密後明文（含姓名、電話）記錄至少三次

- **變更 5**：其他資安與正確性修正
  - 例外回應不再夾帶 `e.getMessage()`，完整堆疊僅記錄於伺服器端
  - `ECCService.decrypt()` 同步加入與正式實作一致的邊界檢核
  - 類別與欄位註解由「RSA 解密」更正為 X25519 ECDH
  - 請求物件補上「金鑰不應經網路傳遞」的警語

### Testing / 測試

#### Test Configuration / 測試配置

本 PR 為 Java / Spring Boot 後端變更，Flutter 與 Dart 欄位不適用。

- Java version：OpenJDK 17.0.20（專案設定 `<java.version>17</java.version>`）
- Build tool：Maven Wrapper（`./mvnw`）
- 受影響模組：`core-system/twdiw-verifier-api`、`SampleCode`
- Device/Emulator：不適用
- OS version：macOS（arm64）

#### Test Cases / 測試案例

- [x] 測試案例 1：`core-system/twdiw-verifier-api` 編譯通過
- [x] 測試案例 2：`SampleCode` 四支檔案編譯通過
- [x] 測試案例 3：ECC 正常加解密往返，確認邊界檢核未誤擋合法資料
- [x] 測試案例 4：送入長度欄位為 `0x7FFFFFFF` 的 `d`，不再觸發 `OutOfMemoryError`
- [x] 測試案例 5：送入長度欄位為負值（`0x80000000`）的 `d`，不再觸發 `NegativeArraySizeException`
- [x] 測試案例 6：送入長度不足（10 bytes）的 `d`，不再觸發陣列越界
- [x] 測試案例 7：長度欄位為 32（裸公鑰長度）而非 44 時正確拒絕
- [x] 測試案例 8：竄改密文時 Poly1305 認證標籤仍正確攔截
- [x] 測試案例 9：竄改明文中的 `phone_number` 會導致 HMAC 改變，確認 HMAC 涵蓋整段明文
- [x] 測試案例 10：TOTP 產生與驗證流程正常

#### Test Results / 測試結果

**編譯結果**

```
core-system/twdiw-verifier-api
  [INFO] Compiling 653 source files with javac [debug parameters release 17]
  [INFO] BUILD SUCCESS
  無新增警告（既有警告皆來自 MapStruct unmapped properties 與 Lombok equals/hashCode，
  與本次變更檔案無關）

SampleCode（以 javac 搭配 Spring／Jackson／SLF4J 相依組成 classpath）
  javac -Xlint:all 結束碼 0，零警告
```

**功能驗證**

撰寫驗證程式實際執行本次修補的行為，以 `-Xmx256m` 執行（修補前 `0x7FFFFFFF` 需配置 2GB，必定觸發 OOM）：

```
[通過] 正常加解密往返 -> 解密結果與明文相同
       封包總長=140 bytes, 長度欄位=44, 明文=64 bytes
[通過] 超大長度欄位 (0x7FFFFFFF) -> IllegalArgumentException: ephemeral 公鑰長度不正確
[通過] 負值長度欄位 (0x80000000) -> IllegalArgumentException: ephemeral 公鑰長度不正確
[通過] 封包長度不足 (10 bytes)   -> IllegalArgumentException: 加密資料長度不足，無法解析
[通過] 長度欄位為 32 而非 44      -> IllegalArgumentException: ephemeral 公鑰長度不正確
[通過] 竄改密文被 Poly1305 攔截   -> 拋出 SecurityException
[通過] 竄改 phone_number 使 HMAC 改變 -> HMAC 涵蓋整段明文，非僅 totp+name
[通過] TOTP 產生並驗證通過        -> 6 位數碼=917405

結果：通過 8 項，失敗 0 項
```

**Spotless 格式檢查**

`mvn spotless:check` 失敗，但**並非本 PR 造成**。以 `git worktree` 檢出本次修改前的 commit（`3a3ce32`）實測，`Dwvp404iService.java` 與 `common/ECCService.java` 兩檔在修改前即已違反 spotless 規則。

根本原因為 google-java-format 要求 2 空格縮排與單一 import 區塊，而現行 codebase 採 4 空格縮排與分組 import。此為既有問題（對應 issue #22「多個模組無法通過 `mvn spotless:check` 格式檢查」），本 PR 未新增任何格式違規，亦未一併修正以避免產生大量與本次議題無關的 diff。

### Screenshots / 截圖

不適用（後端邏輯變更，無 UI 異動）。

### Breaking Changes / 破壞性變更

- [ ] This PR introduces breaking changes / 此 PR 引入破壞性變更

本 PR **不含破壞性變更**：

- API 請求格式（`t`/`d`/`h`/`k`）與回應格式（`decryptionData`）維持不變
- 未新增或變更任何錯誤碼
- 新增的邊界檢核不影響任何合法請求：X25519 SubjectPublicKeyInfo 固定為 44 bytes，數位憑證皮夾產生的 `d` 長度欄位恆為 44，必定通過檢核
- `MessageDigest.isEqual()` 與 `String.equals()` 的比對結果完全相同，僅執行時間特性不同

`SampleCode` 的修改雖幅度較大，但不會破壞任何運作中的整合。原範例要求解密後明文包含 `totp`/`phone`/`hmac`/`name` 四個欄位，而明文中並無 `hmac` 欄位，照原範例實作必定在必要欄位檢核階段失敗，實務上不存在照原範例成功上線的實作。

### Documentation / 文件

- [ ] README.md updated / 已更新 README.md
- [ ] API documentation updated / 已更新 API 文件
- [x] Code comments added/updated / 已新增/更新程式碼註解
- [ ] CHANGELOG.md updated / 已更新 CHANGELOG.md

**說明**：相關規格文件（`Docs/` 下五份）的修正已完成分析但**尚未於本 PR 進行**，將另以獨立 PR 處理，詳見下方「其他備註」。

### Checklist / 檢查清單

#### Code Quality / 程式碼品質

- [x] My code follows the project's code style / 我的程式碼遵循專案的程式碼風格
- [x] I have performed a self-review of my code / 我已對我的程式碼進行自我審查
- [x] I have commented my code, particularly in hard-to-understand areas / 我已註解我的程式碼，特別是在難以理解的區域
- [x] My changes generate no new warnings / 我的變更不會產生新的警告（`mvn compile` 與 `javac -Xlint:all` 均無新增警告）
- [ ] I have added tests / 我已新增測試 — **未納入版控**，說明見下方備註
- [ ] New and existing unit tests pass locally / 單元測試在本地通過 — **`twdiw-verifier-api` 目前無任何測試原始碼**（`src/test` 不存在），無測試套件可執行，故不勾選
- [x] Any dependent changes have been merged and published / 任何相依的變更都已合併並發布（本 PR 無外部相依）

#### Flutter Specific / Flutter 特定

本節不適用。本 PR 為 Java / Spring Boot 後端與 Java 範例程式變更，未涉及 Flutter、Dart 或行動端程式碼。

- [ ] `flutter analyze` — 不適用
- [ ] `flutter format` — 不適用
- [ ] iOS 與 Android 測試 — 不適用
- [ ] 不同螢幕尺寸測試 — 不適用

#### Legal / 法律

<!-- 以下三項涉及法律聲明，須由提交者本人確認後勾選 -->

- [X] I have read and agree to the [Contributor License Agreement](../CLA.md) / 我已閱讀並同意[貢獻者授權協議](../CLA.md)
- [X] This contribution is my original work / 此貢獻是我的原創作品
- [X] I have the right to submit this work under the MIT license / 我有權在 MIT 授權下提交此作品

### Additional Notes / 其他備註

**一、審查重點建議**

建議審查者優先確認 `SampleCode/VerifyQRCodeController.java` 的 HMAC 計算對象是否與 `Dwvp404iService.java:89` 一致，這是本 PR 的核心修正：

```java
// Dwvp404iService（正式實作）
String calculatedHmac = hmacService.calculateHMAC(orgData, orgKeySetting.getHmacKey());

// VerifyQRCodeController（本 PR 修正後）
String calculatedHmac = hmacService.calculateHMAC(decryptedData, request.getHmacKey());
```

兩者皆為對整段解密後明文計算，並與 QR Code 的 `h` 欄位比對，符合 `TWDIW_API_Specification.md` L1394 的定義。

**二、關於測試**

`twdiw-verifier-api` 目前不存在 `src/test` 目錄，整個模組沒有任何測試原始碼；`SampleCode/` 亦無 `pom.xml` 與測試基礎建設，四支檔案的 package 為 `com.example.demo.*`，定位為「文件引用的程式片段」而非可獨立編譯的專案。

本次驗證是以一支獨立的驗證程式完成（涵蓋加解密往返、四種畸形輸入、Poly1305 竄改偵測、HMAC 涵蓋範圍、TOTP 流程，共 8 項），該程式**未納入版控**，因為 `twdiw-verifier-api` 尚無測試基礎建設可供放置。

建議後續補上正式單元測試，優先涵蓋：

- `ECCService.decrypt()` 的四種畸形輸入邊界條件
- `Dwvp404iService` 的 HMAC 比對與 TOTP 驗證分支

若審查者認為應於本 PR 一併建立 `src/test` 並納入上述測試，請告知，可再補提交。

**三、建議通知既有整合商（重要）**

本 PR 修正的是公開範例中的錯誤示範，但已照舊版範例實作的廠商可能已受影響，建議發布時一併通知：

1. **檢查日誌並輪替 HMAC 金鑰**：複製過舊版 `SampleCode/HMACService.java` 的系統，正在將 `hmacKey` 明文寫入 INFO 日誌。請檢視應用程式日誌、日誌集中平台與備份，若確認有記錄，透過 DWVP-05-403 輪替該組金鑰。
2. **TOTP 實際時間窗格**：文件記載「有效 60 秒」，但實作為 60 秒步長搭配前後各一個窗格的容錯，實際可接受時間跨度最長約 180 秒。自行實作 TOTP 驗證的整合商應據此校正。

**四、後續待處理事項**

以下項目已完成分析但不在本 PR 範圍：

- **規格文件修正**（另開 PR）：`Docs/` 下五份文件與正式實作存在多處不一致，包含 `TOTP_Service_Specification.md` 的 `verifyTOTP` 參數順序寫反、`QR Code 驗證規格說明文件.md` 的私鑰範例實為 EC P-256 而非 X25519、`totpKey`／`hmacKey` 範例非合法 Base64、`TWDIW_API_Specification.md` L1268 四個文件連結路徑失效等。
- **防重放機制**（建議另開 issue）：目前約 180 秒的時間窗格內，同一張 QR Code 可被重複掃描驗證通過，正式實作與文件均未提供 nonce 或已用碼記錄機制。此為實質資安缺口，建議獨立評估。
- **CHANGELOG.md**：`core-system/twdiw-verifier-api/CHANGELOG.md` 遵循 Keep a Changelog 格式，目前最新為 `[1.0.0] - 2025-11-27`。本次資安修正建議新增 `### 安全性修正` 區段，可視發版規劃決定於本 PR 或發版時補上。
- **Spotless 格式問題**（對應既有 issue #22）：本 PR 涉及的兩個 `core-system` 檔案在修改前即無法通過 `mvn spotless:check`，根本原因為 google-java-format 的 2 空格縮排規則與現行 codebase 的 4 空格風格衝突。此問題影響範圍遍及多個模組，需要專案層級決策（調整 spotless 設定或全面重新格式化），不宜在本 PR 處理。

### Reviewer Notes / 審查者備註

<!-- Space for reviewers to add their comments -->

---

**Thank you for contributing to Taiwan Digital Wallet!**
**感謝您為數位憑證皮夾做出貢獻！**